### PR TITLE
feat: add 'output' option

### DIFF
--- a/src/plugin/options.ts
+++ b/src/plugin/options.ts
@@ -6,6 +6,37 @@ import {
   type WrappablePlugin,
   type WrappingOptions,
 } from '../wrapping/index.js'
+import type { MessagesASTMap } from './types.js'
+
+/** Represents options for the transformation output. */
+interface OutputOptions {
+  /**
+   * Defines the format of the output file or provides a function that will
+   * encode input JavaScript object containing the messages into a string
+   * representing contents of the transformed file.
+   *
+   * The following formats are supported:
+   *
+   * - `module`, which outputs an ESM JavaScript module.
+   * - `json`, which outputs a JSON string, that can be processed by other
+   *   plugins.
+   *
+   * @default 'module' // The output is an ESM module.
+   */
+  format?: 'module' | 'json' | ((messages: MessagesASTMap) => string)
+
+  /**
+   * Defines what kind of output should be generated.
+   *
+   * The following output types are supported:
+   *
+   * - `raw` - outputs the messages as is.
+   * - `ast` - pre-parses the messages and outputs their AST.
+   *
+   * @default 'ast' // The output is an AST.
+   */
+  type?: 'raw' | 'ast'
+}
 
 /** Represents options for the plugin. */
 export interface Options<PluginType extends WrappablePlugin> {
@@ -13,7 +44,7 @@ export interface Options<PluginType extends WrappablePlugin> {
    * Defines a string or regular expression, or an array of those, that should
    * match with the file ID in order for it to be transformed.
    *
-   * @default '** /*.json' // Match any JSON files by default.
+   * @default '** /*.messages.json' // Match any JSON files by default.
    */
   include?: FilterPattern
 
@@ -115,6 +146,9 @@ export interface Options<PluginType extends WrappablePlugin> {
    * @default false // Plugins wrapping is disabled.
    */
   pluginsWrapping?: boolean | WrappingOptions<PluginType>
+
+  /** Options that allow to configure the output of transformation. */
+  output?: OutputOptions
 }
 
 function normalizeIndent(indent?: Options<any>['indent']) {
@@ -130,6 +164,14 @@ function normalizeWrappingOptions_<PluginType extends WrappablePlugin>(
   )
 }
 
+function normalizeOutputOptions(options?: OutputOptions) {
+  return {
+    ...options,
+    format: options?.format ?? 'module',
+    type: options?.type ?? 'ast',
+  } satisfies OutputOptions
+}
+
 export function normalizeOptions<PluginType extends WrappablePlugin>(
   options?: Options<PluginType>,
 ) {
@@ -142,6 +184,7 @@ export function normalizeOptions<PluginType extends WrappablePlugin>(
     pluginsWrapping: normalizeWrappingOptions_(
       options?.pluginsWrapping ?? false,
     ),
+    output: normalizeOutputOptions(options?.output),
   } satisfies Options<PluginType>
 }
 

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -1,5 +1,4 @@
 import { dataToEsm } from '@rollup/pluginutils'
-import type { MessageFormatElement } from '@formatjs/icu-messageformat-parser'
 import type { CompileFn } from '@formatjs/cli-lib'
 import { createUnplugin, type RollupPlugin } from 'unplugin'
 import { basePluginName } from '../shared/consts.js'
@@ -19,7 +18,7 @@ import { normalizeOptions, type Options } from './options.js'
 import { parseMessages } from './message-parsing.js'
 import { compileMessages } from './message-compiling.js'
 import { readMessagesFile } from './message-reading.js'
-import type { MessagesMap } from './types.js'
+import type { MessagesASTMap, MessagesMap } from './types.js'
 import { createFilter } from './filter.js'
 
 /**
@@ -35,8 +34,14 @@ type Options_ = Options<any> | undefined
 
 /** Unplugin that parses files containing ICU MessageFormat messages into AST. */
 export const plugin = createUnplugin<Options_, false>((options_, meta) => {
-  const { indent, format, parse, pluginsWrapping, ...options } =
-    normalizeOptions(options_ ?? {})
+  const {
+    indent,
+    format,
+    parse,
+    pluginsWrapping,
+    output: outputOpts,
+    ...options
+  } = normalizeOptions(options_ ?? {})
 
   const filter = createFilter(options)
 
@@ -123,7 +128,7 @@ export const plugin = createUnplugin<Options_, false>((options_, meta) => {
     webpack(_compiler) {
       _compiler.options.module.rules.push({
         test: filter,
-        type: 'javascript/auto',
+        type: outputOpts.format === 'json' ? 'json' : 'javascript/auto',
       })
     },
 
@@ -176,19 +181,34 @@ export const plugin = createUnplugin<Options_, false>((options_, meta) => {
         throw new TransformError('Cannot compile the messages', { cause })
       }
 
-      let ast: Record<string, MessageFormatElement[]>
-      try {
-        ast = parseMessages(messages, getParserOptions, id)
-      } catch (cause) {
-        this.error(
-          new TransformError('Cannot generate messages AST', { cause }),
-        )
-        return
+      let data: MessagesASTMap | MessagesMap
+      if (outputOpts.type === 'ast') {
+        try {
+          data = parseMessages(messages, getParserOptions, id)
+        } catch (cause) {
+          this.error(
+            new TransformError('Cannot generate messages AST', { cause }),
+          )
+          return
+        }
+      } else {
+        data = messages
       }
 
-      return {
-        code: dataToEsm(ast, { indent, preferConst: true }),
-        map: { mappings: '' },
+      if (outputOpts.format === 'module') {
+        return {
+          code: dataToEsm(data, { indent, preferConst: true }),
+          map: { mappings: '' },
+        }
+      } else if (outputOpts.format === 'json') {
+        return {
+          code: JSON.stringify(data),
+          map: { mappings: '' },
+        }
+      } else {
+        this.error(
+          new TransformError(`Unsupported output format: ${outputOpts.format}`),
+        )
       }
     },
   }

--- a/src/plugin/types.ts
+++ b/src/plugin/types.ts
@@ -1,2 +1,7 @@
+import type { MessageFormatElement } from '@formatjs/icu-messageformat-parser'
+
 /** Represents a record of raw messages. */
 export type MessagesMap = Record<string, string>
+
+/** Represents a record of parsed messages. */
+export type MessagesASTMap = Record<string, MessageFormatElement[]>

--- a/test/__snapshots__/rollup.test.ts.snap
+++ b/test/__snapshots__/rollup.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`rollup > respects parser options 1`] = `
 "const introduction = [
@@ -147,6 +147,47 @@ function example() {
   const messageId = messageTypes.find(([type]) => options.type === type);
   if (messageId == null) throw new Error(\`Unknown type \${options.type}\`)
   return messages[messageId]
+}
+
+export { example as default };
+"
+`;
+
+exports[`rollup > should transform to JSON of AST 1`] = `
+"var greeting = [
+	{
+		type: 0,
+		value: \\"Hello, \\"
+	},
+	{
+		type: 1,
+		value: \\"name\\"
+	},
+	{
+		type: 0,
+		value: \\"!\\"
+	}
+];
+var messages = {
+	greeting: greeting
+};
+
+function example() {
+  return messages
+}
+
+export { example as default };
+"
+`;
+
+exports[`rollup > should transform to JSON of messages 1`] = `
+"var greeting = \\"Hello, {name}!\\";
+var messages = {
+	greeting: greeting
+};
+
+function example() {
+  return messages
 }
 
 export { example as default };

--- a/test/__snapshots__/vite.test.ts.snap
+++ b/test/__snapshots__/vite.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`vite > should generate bundle 1`] = `
 "const e = [

--- a/test/__snapshots__/webpack.test.ts.snap
+++ b/test/__snapshots__/webpack.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`webpack > should be able to parse using TOML files 1`] = `
 "/******/ // The require scope
@@ -201,6 +201,94 @@ const greeting = [
 
 function example() {
   return en_messages
+}
+
+var __webpack_exports__default = __webpack_exports__.Z;
+export { __webpack_exports__default as default };
+"
+`;
+
+exports[`webpack > should transform to AST JSON 1`] = `
+"/******/ // The require scope
+/******/ var __webpack_require__ = {};
+/******/ 
+/************************************************************************/
+/******/ /* webpack/runtime/define property getters */
+/******/ (() => {
+/******/ 	// define getter functions for harmony exports
+/******/ 	__webpack_require__.d = (exports, definition) => {
+/******/ 		for(var key in definition) {
+/******/ 			if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 				Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 			}
+/******/ 		}
+/******/ 	};
+/******/ })();
+/******/ 
+/******/ /* webpack/runtime/hasOwnProperty shorthand */
+/******/ (() => {
+/******/ 	__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop))
+/******/ })();
+/******/ 
+/************************************************************************/
+var __webpack_exports__ = {};
+
+// EXPORTS
+__webpack_require__.d(__webpack_exports__, {
+  \\"Z\\": () => (/* binding */ example)
+});
+
+;// CONCATENATED MODULE: ./test/fixtures/normal/en.messages.json
+const en_messages_namespaceObject = JSON.parse('{\\"greeting\\":[{\\"type\\":0,\\"value\\":\\"Hello, \\"},{\\"type\\":1,\\"value\\":\\"name\\"},{\\"type\\":0,\\"value\\":\\"!\\"}]}');
+;// CONCATENATED MODULE: ./test/fixtures/normal/input.mjs
+
+
+function example() {
+  return en_messages_namespaceObject
+}
+
+var __webpack_exports__default = __webpack_exports__.Z;
+export { __webpack_exports__default as default };
+"
+`;
+
+exports[`webpack > should transform to JSON of raw messages 1`] = `
+"/******/ // The require scope
+/******/ var __webpack_require__ = {};
+/******/ 
+/************************************************************************/
+/******/ /* webpack/runtime/define property getters */
+/******/ (() => {
+/******/ 	// define getter functions for harmony exports
+/******/ 	__webpack_require__.d = (exports, definition) => {
+/******/ 		for(var key in definition) {
+/******/ 			if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 				Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 			}
+/******/ 		}
+/******/ 	};
+/******/ })();
+/******/ 
+/******/ /* webpack/runtime/hasOwnProperty shorthand */
+/******/ (() => {
+/******/ 	__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop))
+/******/ })();
+/******/ 
+/************************************************************************/
+var __webpack_exports__ = {};
+
+// EXPORTS
+__webpack_require__.d(__webpack_exports__, {
+  \\"Z\\": () => (/* binding */ example)
+});
+
+;// CONCATENATED MODULE: ./test/fixtures/normal/en.messages.json
+const en_messages_namespaceObject = JSON.parse('{\\"greeting\\":\\"Hello, {name}!\\"}');
+;// CONCATENATED MODULE: ./test/fixtures/normal/input.mjs
+
+
+function example() {
+  return en_messages_namespaceObject
 }
 
 var __webpack_exports__default = __webpack_exports__.Z;

--- a/test/rollup.test.ts
+++ b/test/rollup.test.ts
@@ -240,6 +240,62 @@ describe('rollup', () => {
     )
   })
 
+  it('should transform to JSON of AST', async () => {
+    const { generate } = await rollup({
+      input: [
+        resolve(
+          dirname(fileURLToPath(import.meta.url)),
+          'fixtures/normal/input.mjs',
+        ),
+      ],
+      plugins: [
+        icuMessages({
+          format: 'crowdin',
+          output: {
+            format: 'json',
+          },
+        }),
+        json(),
+      ],
+    })
+
+    const { output } = await generate({
+      format: 'esm',
+    })
+
+    expect(output).toHaveLength(1)
+    expect(output[0]?.code).toMatchSnapshot()
+  })
+
+  it('should transform to JSON of messages', async () => {
+    // same as above, but output.type set to raw
+    const { generate } = await rollup({
+      input: [
+        resolve(
+          dirname(fileURLToPath(import.meta.url)),
+          'fixtures/normal/input.mjs',
+        ),
+      ],
+      plugins: [
+        icuMessages({
+          format: 'crowdin',
+          output: {
+            format: 'json',
+            type: 'raw',
+          },
+        }),
+        json(),
+      ],
+    })
+
+    const { output } = await generate({
+      format: 'esm',
+    })
+
+    expect(output).toHaveLength(1)
+    expect(output[0]?.code).toMatchSnapshot()
+  })
+
   it('exposes filter in public API', () => {
     expect(icuMessages({}).api).toHaveProperty('filter')
   })

--- a/test/webpack.test.ts
+++ b/test/webpack.test.ts
@@ -155,8 +155,39 @@ describe(
 
       expect(out).toMatchSnapshot()
     })
+
+    it('should transform to AST JSON', async () => {
+      const out = await buildFile('fixtures/normal/input.mjs', (config) => {
+        ;(config.plugins ??= []).push(
+          icuMessages({
+            include: '**/*.messages.json',
+            format: 'crowdin',
+            output: {
+              format: 'json',
+            },
+          }),
+        )
+      })
+
+      expect(out).toMatchSnapshot()
+    })
+
+    it('should transform to JSON of raw messages', async () => {
+      const out = await buildFile('fixtures/normal/input.mjs', (config) => {
+        ;(config.plugins ??= []).push(
+          icuMessages({
+            include: '**/*.messages.json',
+            format: 'crowdin',
+            output: {
+              type: 'raw',
+              format: 'json',
+            },
+          }),
+        )
+      })
+
+      expect(out).toMatchSnapshot()
+    })
   },
-  {
-    timeout: 60_000,
-  },
+  { timeout: 60_000 },
 )


### PR DESCRIPTION
`output` option allows to configure the expected output from the plugin, making it able to output transformed JSON without actually pre-parsing any of the messages, and staying compatible with other JSON plugins.

Resolves #13 