### PR TITLE
fix: allow to call `buildStart` multiple times

### DIFF
--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -83,7 +83,13 @@ export const plugin = createUnplugin<Options_, false>((options_, meta) => {
         throw new BaseError('buildStart() has already been called')
       }
 
-      return (buildStartCall = resolveFormatter())
+      return (buildStartCall = (async () => {
+        try {
+          return await resolveFormatter()
+        } finally {
+          buildStartCall = undefined
+        }
+      })())
     }
 
     return {


### PR DESCRIPTION
From what I gathered, `buildStart` can be called again during the second
build using the same configuration. Since we never cleaned
`buildStartCall`, it resulted in some builds breaking.

This commit tries to address this by wrapping the call to
`resolveFormatter` in try-finally and cleaning `buildStartCall` no
matter the result of the call. Hopefully this works.
